### PR TITLE
Fix pylint errors

### DIFF
--- a/examples/mcp2515_canio_test.py
+++ b/examples/mcp2515_canio_test.py
@@ -12,6 +12,7 @@
 CAN_TYPE = None
 try:
     from canio import (
+        CAN,
         Message,
         RemoteTransmissionRequest,
         Match,


### PR DESCRIPTION
Fixes the following `pylint` errors:

```
 ************* Module mcp2515_canio_test
Error: examples/mcp2515_canio_test.py:25:15: E0601: Using variable 'CAN' before assignment (used-before-assignment)
```