### PR TITLE
When available, use core `Message` and `RemoteTransmissionRequest`

### DIFF
--- a/adafruit_mcp2515/__init__.py
+++ b/adafruit_mcp2515/__init__.py
@@ -266,21 +266,7 @@ def _tx_buffer_status_decode(status_byte):
 
 
 class MCP2515:  # pylint:disable=too-many-instance-attributes
-    """A common shared-bus protocol."""
-
-    def __init__(
-        self,
-        spi_bus,
-        cs_pin,
-        *,
-        baudrate: int = 250000,
-        crystal_freq: Literal[8000000, 10000000, 16000000] = 16000000,
-        loopback: bool = False,
-        silent: bool = False,
-        auto_restart: bool = False,
-        debug: bool = False,
-    ):
-        """A common shared-bus protocol.
+    """A common shared-bus protocol.
 
         :param ~busio.SPI spi: The SPI bus used to communicate with the MCP2515
         :param ~digitalio.DigitalInOut cs_pin:  SPI bus enable pin
@@ -297,9 +283,21 @@ class MCP2515:  # pylint:disable=too-many-instance-attributes
         :param bool auto_restart: **Not supported by hardware. An `AttributeError` will be raised\
         if `auto_restart` is set to `True`** If `True`, will restart communications after entering\
         bus-off state. Defaults to `False`.
-
         :param bool debug: If `True`, will enable printing debug information. Defaults to `False`.
         """
+
+    def __init__(
+        self,
+        spi_bus,
+        cs_pin,
+        *,
+        baudrate: int = 250000,
+        crystal_freq: Literal[8000000, 10000000, 16000000] = 16000000,
+        loopback: bool = False,
+        silent: bool = False,
+        auto_restart: bool = False,
+        debug: bool = False,
+    ):
 
         if loopback and not silent:
             raise AttributeError("Loopback mode requires silent to be set")

--- a/adafruit_mcp2515/__init__.py
+++ b/adafruit_mcp2515/__init__.py
@@ -264,7 +264,7 @@ class MCP2515:  # pylint:disable=too-many-instance-attributes
 
         :param ~busio.SPI spi: The SPI bus used to communicate with the MCP2515
         :param ~digitalio.DigitalInOut cs_pin:  SPI bus enable pin
-        :param int baudrate: The bit rate of the bus in Hz, using a 16Mhz crystal. All devices on\
+        :param int baudrate: The bit rate of the bus in Hz. All devices on\
             the bus must agree on this value. Defaults to 250000.
         :param Literal crystal_freq: MCP2515 crystal frequency. Valid values are:\
             16000000, 10000000 and 8000000. Defaults to 16000000 (16MHz).\

--- a/adafruit_mcp2515/__init__.py
+++ b/adafruit_mcp2515/__init__.py
@@ -158,14 +158,8 @@ _EFLG = const(0x2D)
 _SEND_TIMEOUT_MS = const(5)  # 500ms
 _MAX_CAN_MSG_LEN = 8  # ?!
 # perhaps this will be stateful later?
-TransmitBuffer = namedtuple(
-    "TransmitBuffer",
-    ["CTRL_REG", "STD_ID_REG", "INT_FLAG_MASK", "LOAD_CMD", "SEND_CMD"],
-)
-
-# perhaps this will be stateful later? #TODO : dedup with above
-ReceiveBuffer = namedtuple(
-    "TransmitBuffer",
+_TransmitBuffer = namedtuple(
+    "_TransmitBuffer",
     ["CTRL_REG", "STD_ID_REG", "INT_FLAG_MASK", "LOAD_CMD", "SEND_CMD"],
 )
 
@@ -330,21 +324,21 @@ class MCP2515:  # pylint:disable=too-many-instance-attributes
     def _init_buffers(self):
 
         self._tx_buffers = [
-            TransmitBuffer(
+            _TransmitBuffer(
                 CTRL_REG=_TXB0CTRL,
                 STD_ID_REG=_TXB0SIDH,
                 INT_FLAG_MASK=_TX0IF,
                 LOAD_CMD=_LOAD_TX0,
                 SEND_CMD=_SEND_TX0,
             ),
-            TransmitBuffer(
+            _TransmitBuffer(
                 CTRL_REG=_TXB1CTRL,
                 STD_ID_REG=_TXB1SIDH,
                 INT_FLAG_MASK=_TX1IF,
                 LOAD_CMD=_LOAD_TX1,
                 SEND_CMD=_SEND_TX1,
             ),
-            TransmitBuffer(
+            _TransmitBuffer(
                 CTRL_REG=_TXB2CTRL,
                 STD_ID_REG=_TXB2SIDH,
                 INT_FLAG_MASK=_TX2IF,

--- a/adafruit_mcp2515/canio/__init__.py
+++ b/adafruit_mcp2515/canio/__init__.py
@@ -67,6 +67,13 @@ class RemoteTransmissionRequest:
         self.extended = extended
 
 
+# Replace the above implementation with core canio implementation if it is available
+try:
+    from canio import Message, RemoteTransmissionRequest
+except ImportError:
+    pass
+
+
 class Listener:
     """Listens for a CAN message
 

--- a/adafruit_mcp2515/canio/__init__.py
+++ b/adafruit_mcp2515/canio/__init__.py
@@ -89,8 +89,8 @@ class Listener:
 
     @property
     def timeout(self):
-        """The maximum amount of time in seconds that `read` or `readinto` will wait before giving\
-            up"""
+        """The maximum amount of time in seconds that ``read`` or ``readinto``
+        will wait before giving up"""
         return self._timeout
 
     @timeout.setter

--- a/adafruit_mcp2515/canio/__init__.py
+++ b/adafruit_mcp2515/canio/__init__.py
@@ -14,13 +14,10 @@ class Message:
     def __init__(self, id, data, extended=False):
         """Create a `Message` to send
 
-        Args:
-            id (int): The numeric ID of the message
-            data (bytes): The content of the message
-            extended (bool): True if the
-        Raises:
-            AttributeError: If `data` of type `bytes` is not provided for a non-RTR message
-            AttributeError: If `data` is larger than 8 bytes
+        :param int id: The numeric ID of the message
+        :param bytes data: The content of the message, from 0 to 8 bytes of data
+        :param bool extended: True if the message has an extended identifier,
+            False if it has a standard identifier
         """
 
         self._data = None
@@ -28,9 +25,15 @@ class Message:
         self.data = data
         self.extended = extended
 
+    id: int
+    """The numeric ID of the message"""
+
+    extended: bool
+    """Indicates whether the the message has an extended identifier"""
+
     @property
     def data(self):
-        """The content of the message, or dummy content in the case of an rtr"""
+        """The content of the message"""
         return self._data
 
     @data.setter
@@ -56,15 +59,23 @@ class RemoteTransmissionRequest:
         """Construct a RemoteTransmissionRequest to send on a CAN bus
 
         Args:
-            id (int): The numeric ID of the requested message
-            length (int): The length of the requested message
-            extended (bool, optional): True if the message has an extended identifier, False if it\
-                has a standard identifier. Defaults to False.
-
+        :param int id: The numeric ID of the message
+        :param length int: The length of the requested message
+        :param bool extended: True if the message has an extended identifier,
+            False if it has a standard identifier
         """
         self.id = id
         self.length = length
         self.extended = extended
+
+    id: int
+    """The numeric ID of the message"""
+
+    extended: bool
+    """Indicates whether the the message has an extended identifier"""
+
+    length: int
+    """The length of the requested message, from 0 to 8"""
 
 
 # Replace the above implementation with core canio implementation if it is available

--- a/adafruit_mcp2515/canio/__init__.py
+++ b/adafruit_mcp2515/canio/__init__.py
@@ -8,18 +8,16 @@ from ..timer import Timer
 
 
 class Message:
-    """A class representing a CANbus data frame"""
+    """A class representing a CANbus data frame
+
+    :param int id: The numeric ID of the message
+    :param bytes data: The content of the message, from 0 to 8 bytes of data
+    :param bool extended: True if the message has an extended identifier,
+        False if it has a standard identifier
+    """
 
     # pylint:disable=too-many-arguments,invalid-name,redefined-builtin
     def __init__(self, id, data, extended=False):
-        """Create a `Message` to send
-
-        :param int id: The numeric ID of the message
-        :param bytes data: The content of the message, from 0 to 8 bytes of data
-        :param bool extended: True if the message has an extended identifier,
-            False if it has a standard identifier
-        """
-
         self._data = None
         self.id = id
         self.data = data
@@ -53,17 +51,15 @@ class Message:
 
 
 class RemoteTransmissionRequest:
-    """A class representing a CANbus remote frame"""
+    """A class representing a CANbus remote frame
+
+    :param int id: The numeric ID of the message
+    :param length int: The length of the requested message
+    :param bool extended: True if the message has an extended identifier,
+        False if it has a standard identifier
+    """
 
     def __init__(self, id: int, length: int, *, extended: bool = False):
-        """Construct a RemoteTransmissionRequest to send on a CAN bus
-
-        Args:
-        :param int id: The numeric ID of the message
-        :param length int: The length of the requested message
-        :param bool extended: True if the message has an extended identifier,
-            False if it has a standard identifier
-        """
         self.id = id
         self.length = length
         self.extended = extended
@@ -88,8 +84,8 @@ except ImportError:
 class Listener:
     """Listens for a CAN message
 
-        canio.Listener is not constructed directly, but instead by calling the `listen` method of a\
-        canio.CAN object.
+    canio.Listener is not constructed directly, but instead by calling the
+    ``listen`` method of a canio.CAN object.
     """
 
     def __init__(self, can_bus_obj, timeout=1.0):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,3 +6,5 @@
 
 .. automodule:: adafruit_mcp2515
    :members:
+.. automodule:: adafruit_mcp2515.canio
+   :members:


### PR DESCRIPTION
…classes

Otherwise, a user may unintentionally send a `canio.Message` to an `adafruit_mcp2515.MCP2515` instance, and it will be incorrectly interpreted due to the type checking for whether the message is a `RemoteTransmissionRequest`